### PR TITLE
Add Tracker model and ORM search

### DIFF
--- a/apps/api/app/db/models.py
+++ b/apps/api/app/db/models.py
@@ -1,7 +1,8 @@
 from sqlalchemy.orm import Mapped, mapped_column
-from sqlalchemy import String, Integer, Float, DateTime, Text
+from sqlalchemy import String, Integer, Float, DateTime, Text, Boolean
 from datetime import datetime
-from app.db.session import Base, engine
+from app.db.session import Base, engine, SessionLocal
+from app.core.config import settings
 
 class Download(Base):
     __tablename__ = "downloads"
@@ -17,5 +18,32 @@ class Download(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     completed_at: Mapped[datetime | None] = mapped_column(DateTime)
 
+
+class Tracker(Base):
+    __tablename__ = "trackers"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(64))
+    type: Mapped[str] = mapped_column(String(16))
+    base_url: Mapped[str | None] = mapped_column(String(255))
+    creds_enc: Mapped[str | None] = mapped_column(String(512))
+    enabled: Mapped[bool] = mapped_column(Boolean, default=True)
+
 # bootstrap (MVP): создаём таблицы при старте
 Base.metadata.create_all(bind=engine)
+
+
+if settings.APP_ENV == "dev":
+    with SessionLocal() as db:
+        if not db.query(Tracker).first():
+            sample = [
+                Tracker(
+                    name="Example",
+                    type="torznab",
+                    base_url="https://example.com",
+                    creds_enc="",
+                    enabled=False,
+                )
+            ]
+            db.add_all(sample)
+            db.commit()

--- a/apps/api/app/routers/search.py
+++ b/apps/api/app/routers/search.py
@@ -1,9 +1,7 @@
 from fastapi import APIRouter, HTTPException
-from sqlalchemy import select
 from app.db.session import session_scope
-from app.db.models import Download
+from app.db.models import Tracker
 from app.services.search.torznab import TorznabClient
-import asyncio
 
 router = APIRouter()
 
@@ -15,7 +13,7 @@ async def search(query: str):
     results = []
 
     with session_scope() as db:
-        trackers = db.execute("SELECT * FROM trackers WHERE enabled=1").fetchall()
+        trackers = db.query(Tracker).filter_by(enabled=True).all()
 
     for tr in trackers:
         if tr.type == "torznab" and tr.base_url:


### PR DESCRIPTION
## Summary
- add Tracker ORM model and dev seed data
- query enabled trackers via ORM in search router

## Testing
- `python -m py_compile apps/api/app/db/models.py apps/api/app/routers/search.py`
- `PYTHONPATH=apps/api python - <<'PY'
from app.db.models import Base, engine
Base.metadata.create_all(bind=engine)
print('done')
PY` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_68b1698c582c8329945a4166fa45ee37