### PR TITLE
feat: implement JWT auth and protect routes

### DIFF
--- a/apps/api/app/core/security.py
+++ b/apps/api/app/core/security.py
@@ -1,11 +1,44 @@
 from datetime import datetime, timedelta
-from jose import jwt
+from jose import JWTError, jwt
 from passlib.context import CryptContext
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+from app.core.config import settings
+from app.db.session import session_scope
+from app.db.models import User
 
 ALGO = "HS256"
 _pwd = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+auth_scheme = HTTPBearer()
+
 
 def create_token(subject: str, secret: str, expires_minutes: int = 60) -> str:
     now = datetime.utcnow()
     payload = {"sub": subject, "iat": now, "exp": now + timedelta(minutes=expires_minutes)}
     return jwt.encode(payload, secret, algorithm=ALGO)
+
+
+def hash_password(password: str) -> str:
+    return _pwd.hash(password)
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    return _pwd.verify(password, hashed)
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(auth_scheme),
+) -> User:
+    token = credentials.credentials
+    try:
+        payload = jwt.decode(token, settings.APP_SECRET, algorithms=[ALGO])
+        user_id = int(payload.get("sub"))
+    except (JWTError, ValueError):
+        raise HTTPException(status_code=401, detail="Invalid token")
+    with session_scope() as db:
+        user = db.get(User, user_id)
+        if not user:
+            raise HTTPException(status_code=401, detail="Invalid token")
+        return user

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -1,12 +1,29 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.core.config import settings
+from app.core.security import create_token, verify_password, get_current_user
+from app.db.session import session_scope
+from app.db.models import User
 
 router = APIRouter()
 
+
+class Credentials(BaseModel):
+    email: str
+    password: str
+
+
 @router.post("/auth/login")
-async def login(payload: dict):
-    # MVP stub — возвращаем фиктивный токен
-    return {"accessToken": "dev-token", "tokenType": "Bearer"}
+def login(payload: Credentials):
+    with session_scope() as db:
+        user = db.query(User).filter_by(email=payload.email).first()
+        if not user or not verify_password(payload.password, user.hashed_password):
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        token = create_token(str(user.id), settings.APP_SECRET)
+        return {"accessToken": token, "tokenType": "Bearer"}
+
 
 @router.get("/me")
-async def me():
-    return {"id": "dev", "email": "dev@example", "role": "admin"}
+def me(current_user: User = Depends(get_current_user)):
+    return {"id": current_user.id, "email": current_user.email, "role": current_user.role}

--- a/apps/api/app/routers/downloads.py
+++ b/apps/api/app/routers/downloads.py
@@ -1,14 +1,15 @@
-from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect, Depends
 from pydantic import BaseModel
 from pathlib import Path
 import asyncio
 from app.db.session import session_scope
 from app.db.models import Download
+from app.core.security import get_current_user
 from app.core.config import settings
 from app.services.jobs.tasks import enqueue_magnet, poll_status
 from app.services.bt.qbittorrent import QbClient
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 class DownloadIn(BaseModel):
     magnet: str

--- a/apps/api/app/routers/search.py
+++ b/apps/api/app/routers/search.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
 from app.db.session import session_scope
 from app.db.models import Tracker
+from app.core.security import get_current_user
 from app.services.search.torznab import TorznabClient
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(get_current_user)])
 
 @router.get("/search")
 async def search(query: str):


### PR DESCRIPTION
## Summary
- add SQLAlchemy `User` model with role and seed dev admin
- implement password hashing, token creation, and user retrieval helpers
- replace stubbed auth endpoints with real login and profile logic
- secure downloads and search APIs via auth dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1872391e483299135491030084233