### PR TITLE
Track torrents by hash

### DIFF
--- a/apps/api/app/services/jobs/tasks.py
+++ b/apps/api/app/services/jobs/tasks.py
@@ -11,31 +11,40 @@ celery_app = Celery(
     backend=settings.CELERY_RESULT_BACKEND,
 )
 
-# Simple status poller by torrent list (MVP). In production, track hash/id explicitly.
 async def _update_status(download_id: int):
     qb = QbClient(settings.QB_URL, settings.QB_USER, settings.QB_PASS)
-    await qb.login()
-    items = await qb.list_torrents()
-    # naive: take the last added torrent as the one we just enqueued if id has no client_torrent_id
+    # fetch torrent hash from DB
+    with session_scope() as db:
+        dl = db.get(Download, download_id)
+        if not dl or not dl.client_torrent_id:
+            return
+        torrent_hash = dl.client_torrent_id
+
+    info = await qb.info_by_hash(torrent_hash)
+    if not info:
+        return
+
     with session_scope() as db:
         dl = db.get(Download, download_id)
         if not dl:
             return
-        if items:
-            # Find best match by save_path (if unique) else pick most recent
-            item = sorted(items, key=lambda x: x.get('added_on', 0), reverse=True)[0]
-            dl.client_torrent_id = item.get('hash')
-            dl.progress = float(item.get('progress', 0.0))
-            dl.status = item.get('state', 'downloading')
-            dl.rate_down = int(item.get('dlspeed', 0))
-            dl.rate_up = int(item.get('upspeed', 0))
-            dl.eta_sec = int(item.get('eta', -1)) if item.get('eta') not in (None, -1) else None
+        dl.progress = float(info.get('progress', 0.0))
+        dl.status = info.get('state', 'downloading')
+        dl.rate_down = int(info.get('dlspeed', 0))
+        dl.rate_up = int(info.get('upspeed', 0))
+        eta = info.get('eta')
+        dl.eta_sec = int(eta) if eta not in (None, -1) else None
 
 @celery_app.task
 def enqueue_magnet(download_id: int, magnet: str, save_path: str | None = None):
     async def _run():
         qb = QbClient(settings.QB_URL, settings.QB_USER, settings.QB_PASS)
-        await qb.add_magnet(magnet, save_path)
+        torrent_hash = await qb.add_magnet(magnet, save_path)
+        if torrent_hash:
+            with session_scope() as db:
+                dl = db.get(Download, download_id)
+                if dl:
+                    dl.client_torrent_id = torrent_hash
         # initial status write
         await _update_status(download_id)
     asyncio.run(_run())


### PR DESCRIPTION
## Summary
- extract torrent hash when adding magnet links
- persist hash in Download record
- update status polling to query qBittorrent by stored hash

## Testing
- `python -m py_compile apps/api/app/services/bt/qbittorrent.py apps/api/app/services/jobs/tasks.py`


------
https://chatgpt.com/codex/tasks/task_e_68b18d158b6c832980e7cb84ab24771a