### PR TITLE
Use logging for tracker warnings

### DIFF
--- a/apps/api/app/routers/search.py
+++ b/apps/api/app/routers/search.py
@@ -1,8 +1,12 @@
+import logging
+
 from fastapi import APIRouter, HTTPException, Depends
 from app.db.session import session_scope
 from app.db.models import Tracker
 from app.core.security import get_current_user
 from app.services.search.torznab import TorznabClient
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(dependencies=[Depends(get_current_user)])
 
@@ -23,7 +27,7 @@ async def search(query: str):
                 res = await client.search(query)
                 results.extend(res)
             except Exception as e:
-                print(f"[WARN] Tracker {tr.name} failed: {e}")
+                logger.warning(f"Tracker {tr.name} failed: {e}")
                 continue
 
     results.sort(key=lambda x: (x["seeds"], x["size"]), reverse=True)


### PR DESCRIPTION
## Summary
- add a logger in the search router
- warn via logger when a tracker search fails

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a993d2c483298b766678139896c8