### PR TITLE
Add Jackett API key support to adapter requests

### DIFF
--- a/apps/api/app/services/jackett_adapter.py
+++ b/apps/api/app/services/jackett_adapter.py
@@ -24,6 +24,11 @@ class JackettAdapter:
     def __init__(self) -> None:
         self.base = JACKETT_BASE.rstrip("/")
 
+    def _auth_headers(self) -> Dict[str, str]:
+        if JACKETT_API_KEY:
+            return {"X-Api-Key": JACKETT_API_KEY}
+        return {}
+
     # ------------ discovery ------------
     def _read_catalog(self) -> List[Dict[str, Any]]:
         try:
@@ -41,7 +46,7 @@ class JackettAdapter:
         """
         url = f"{self.base}/api/v2.0/indexers"
         try:
-            r = httpx.get(url, timeout=10)
+            r = httpx.get(url, timeout=10, headers=self._auth_headers())
             r.raise_for_status()
             data = r.json()
             if not isinstance(data, list):
@@ -53,7 +58,7 @@ class JackettAdapter:
 
     def _get_schema(self, slug: str) -> Dict[str, Any]:
         url = f"{self.base}/api/v2.0/indexers/{slug}/schema"
-        r = httpx.get(url, timeout=10)
+        r = httpx.get(url, timeout=10, headers=self._auth_headers())
         r.raise_for_status()
         return r.json()
 
@@ -143,7 +148,7 @@ class JackettAdapter:
                     payload[f] = v
 
             url = f"{self.base}/api/v2.0/indexers/{slug}/config"
-            r = httpx.post(url, json=payload, timeout=15)
+            r = httpx.post(url, json=payload, timeout=15, headers=self._auth_headers())
             r.raise_for_status()
             return {"slug": slug, "configured": True}
         except httpx.HTTPStatusError as e:

--- a/apps/api/tests/test_jackett_adapter.py
+++ b/apps/api/tests/test_jackett_adapter.py
@@ -1,0 +1,63 @@
+from typing import Any, Dict
+
+from app.services import jackett_adapter
+
+
+class DummyResponse:
+    def __init__(self, payload: Any) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:  # pragma: no cover - nothing to do
+        return None
+
+    def json(self) -> Any:  # pragma: no cover - nothing to do
+        return self._payload
+
+
+def test_fetch_indexers_uses_api_key(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    def fake_get(url, timeout, headers=None, **kwargs):
+        captured.update({"url": url, "timeout": timeout, "headers": headers, "extra": kwargs})
+        return DummyResponse([])
+
+    monkeypatch.setattr(jackett_adapter, "JACKETT_API_KEY", "secret")
+    monkeypatch.setattr(jackett_adapter.httpx, "get", fake_get)
+
+    adapter = jackett_adapter.JackettAdapter()
+    assert adapter._fetch_indexers() == []
+    assert captured["headers"] == {"X-Api-Key": "secret"}
+
+
+def test_get_schema_uses_api_key(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    def fake_get(url, timeout, headers=None, **kwargs):
+        captured.update({"url": url, "timeout": timeout, "headers": headers, "extra": kwargs})
+        return DummyResponse({"fields": []})
+
+    monkeypatch.setattr(jackett_adapter, "JACKETT_API_KEY", "another-secret")
+    monkeypatch.setattr(jackett_adapter.httpx, "get", fake_get)
+
+    adapter = jackett_adapter.JackettAdapter()
+    assert adapter._get_schema("slug") == {"fields": []}
+    assert captured["headers"] == {"X-Api-Key": "another-secret"}
+
+
+def test_ensure_installed_uses_api_key(monkeypatch):
+    captured: Dict[str, Any] = {}
+
+    def fake_post(url, json=None, timeout=None, headers=None, **kwargs):
+        captured.update({"url": url, "json": json, "timeout": timeout, "headers": headers, "extra": kwargs})
+        return DummyResponse({})
+
+    def fake_get_schema(self, slug):
+        return {"fields": []}
+
+    monkeypatch.setattr(jackett_adapter, "JACKETT_API_KEY", "post-secret")
+    monkeypatch.setattr(jackett_adapter.httpx, "post", fake_post)
+    monkeypatch.setattr(jackett_adapter.JackettAdapter, "_get_schema", fake_get_schema)
+
+    adapter = jackett_adapter.JackettAdapter()
+    assert adapter.ensure_installed("slug") == {"slug": "slug", "configured": True}
+    assert captured["headers"] == {"X-Api-Key": "post-secret"}


### PR DESCRIPTION
## Summary
- ensure the Jackett adapter attaches the API key header when listing indexers, fetching schemas, and installing
- centralize Jackett authentication header construction
- add unit tests covering API key usage in adapter requests

## Testing
- pytest apps/api/tests/test_jackett_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68ca913924608329b7d8d3e63086a18e