### PR TITLE
Add discovery services and browse rails

### DIFF
--- a/apps/api/app/api/routes/__init__.py
+++ b/apps/api/app/api/routes/__init__.py
@@ -1,0 +1,3 @@
+from . import discovery
+
+__all__ = ["discovery"]

--- a/apps/api/app/api/routes/discovery.py
+++ b/apps/api/app/api/routes/discovery.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core.cache import cache_get, cache_set
+from app.core.config import settings
+from app.core.redis import get_redis
+from app.services.discovery_apple import apple_feed
+from app.services.discovery_genres import CURATED
+from app.services.discovery_lb import similar_artists
+from app.services.discovery_mb import new_releases_by_genre
+
+router = APIRouter(prefix="/api/v1/discovery", tags=["discovery"])
+TTL = getattr(settings, "DISCOVERY_CACHE_TTL", 86_400)
+
+
+@router.get("/genres")
+def genres() -> dict[str, object]:
+    return {"genres": CURATED}
+
+
+@router.get("/new")
+def new(
+    genre: str,
+    days: int = 30,
+    limit: int = 50,
+    redis=Depends(get_redis),
+) -> dict[str, object]:
+    cache_key = f"disc:new:{genre}:{days}:{limit}"
+    cached = cache_get(redis, cache_key)
+    if cached is not None:
+        return cached
+    try:
+        items = new_releases_by_genre(genre, days, limit)
+        payload = {"source": "musicbrainz", "items": items}
+    except Exception as exc:  # pragma: no cover - converted into HTTP error
+        raise HTTPException(status_code=502, detail=f"MusicBrainz error: {exc}") from exc
+    cache_set(redis, cache_key, payload, TTL)
+    return payload
+
+
+@router.get("/top")
+def top(
+    genre_id: int,
+    feed: str = "most-recent",
+    kind: str = "albums",
+    limit: int = 50,
+    storefront: Optional[str] = None,
+    redis=Depends(get_redis),
+) -> dict[str, object]:
+    storefront_code = storefront or getattr(settings, "APPLE_RSS_STOREFRONT", "us")
+    cache_key = f"disc:top:{storefront_code}:{genre_id}:{feed}:{kind}:{limit}"
+    cached = cache_get(redis, cache_key)
+    if cached is not None:
+        return cached
+    try:
+        items = apple_feed(storefront_code, genre_id, feed, kind, limit)
+        payload = {"source": "apple", "items": items}
+    except Exception as exc:  # pragma: no cover - converted into HTTP error
+        raise HTTPException(status_code=502, detail=f"Apple RSS error: {exc}") from exc
+    cache_set(redis, cache_key, payload, TTL)
+    return payload
+
+
+@router.get("/similar-artists")
+def similar(
+    artist_mbid: str,
+    limit: int = 20,
+    redis=Depends(get_redis),
+) -> dict[str, object]:
+    cache_key = f"disc:sim:{artist_mbid}:{limit}"
+    cached = cache_get(redis, cache_key)
+    if cached is not None:
+        return cached
+    try:
+        items = similar_artists(artist_mbid, limit)
+        payload = {"source": "listenbrainz", "items": items}
+    except Exception as exc:  # pragma: no cover - converted into HTTP error
+        raise HTTPException(status_code=502, detail=f"ListenBrainz error: {exc}") from exc
+    cache_set(redis, cache_key, payload, TTL)
+    return payload
+
+
+__all__ = ["router"]

--- a/apps/api/app/api/v1/endpoints/details.py
+++ b/apps/api/app/api/v1/endpoints/details.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session
 
 from app.db.session import get_db
 from app.schemas.media import Classification
-from app.schemas.ui import DetailLinks, DetailResponse, DiscoverItem
+from app.schemas.ui import DetailLinks, DetailResponse, DiscoverItem, MusicBrainzInfo
 from app.services import library as library_service
 from app.services.metadata import get_metadata_router
 from app.services.metadata.providers.tmdb import TMDB_IMAGE_BASE
@@ -178,6 +178,9 @@ def _build_detail(card, response_kind: str, item_id: str, snapshot: dict | None)
 
     cast_items, crew_items = _collect_people(_ensure_dict(tmdb_extra.get("credits")))
 
+    artist_info = _ensure_dict(musicbrainz_data.get("artist"))
+    release_group_info = _ensure_dict(musicbrainz_data.get("release_group"))
+
     detail = DetailResponse(
         id=item_id,
         kind=response_kind,
@@ -215,6 +218,11 @@ def _build_detail(card, response_kind: str, item_id: str, snapshot: dict | None)
         similar=_extract_similar(tmdb_extra.get("similar"), card.media_type),
         recommended=_extract_similar(
             tmdb_extra.get("recommendations"), card.media_type
+        ),
+        musicbrainz=MusicBrainzInfo(
+            artist_id=artist_info.get("id"),
+            artist_name=artist_info.get("name"),
+            release_group_id=release_group_info.get("id"),
         ),
     )
 

--- a/apps/api/app/core/cache.py
+++ b/apps/api/app/core/cache.py
@@ -1,0 +1,21 @@
+import json
+from typing import Any
+
+
+def cache_get(client, key: str):
+    value = client.get(key)
+    if not value:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8")
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return None
+
+
+def cache_set(client, key: str, data: Any, ttl: int) -> None:
+    client.set(key, json.dumps(data), ex=ttl)
+
+
+__all__ = ["cache_get", "cache_set"]

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -58,6 +58,12 @@ class Settings(BaseSettings):
     # Optional Last.fm key used to surface listening metrics and tags.
     LASTFM_API_KEY: str | None = None
 
+    # Apple Music RSS storefront used for discovery feeds.
+    APPLE_RSS_STOREFRONT: str = "us"
+
+    # Default cache TTL for discovery endpoints (seconds).
+    DISCOVERY_CACHE_TTL: int = 86_400
+
     # MusicBrainz encourages clients to send an informative user agent.
     # We ship a sensible default that complies with their etiquette.
     MB_USER_AGENT: str = "Phelia/0.1 (https://example.local)"

--- a/apps/api/app/core/redis.py
+++ b/apps/api/app/core/redis.py
@@ -1,0 +1,22 @@
+from collections.abc import Generator
+from functools import lru_cache
+
+import redis
+
+from app.core.config import settings
+
+
+@lru_cache(maxsize=1)
+def _redis_client() -> redis.Redis:
+    return redis.Redis.from_url(settings.REDIS_URL)
+
+
+def get_redis() -> Generator[redis.Redis, None, None]:
+    client = _redis_client()
+    try:
+        yield client
+    finally:
+        pass
+
+
+__all__ = ["get_redis"]

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from app.db.init_db import init_db
 from app.db.session import session_scope
 from app.routers import health, auth, downloads, trackers
+from app.api.routes import discovery as discovery_routes
 from app.api.v1.endpoints import discover as discover_endpoints
 from app.api.v1.endpoints import meta as meta_endpoints
 from app.api.v1.endpoints import search as metadata_search
@@ -40,6 +41,7 @@ app.include_router(trackers.router, prefix="/api/v1")
 app.include_router(metadata_search.router, prefix="/api/v1")
 app.include_router(meta_endpoints.public_router, prefix="/api/v1/meta")
 app.include_router(discover_endpoints.router, prefix="/api/v1")
+app.include_router(discovery_routes.router)
 app.include_router(index_endpoints.router, prefix="/api/v1/index")
 app.include_router(capabilities_endpoints.router, prefix="/api/v1")
 app.include_router(library_endpoints.router, prefix="/api/v1")

--- a/apps/api/app/schemas/ui.py
+++ b/apps/api/app/schemas/ui.py
@@ -127,6 +127,12 @@ class DetailLinks(BaseModel):
     external: list[ExternalLink] | None = None
 
 
+class MusicBrainzInfo(BaseModel):
+    artist_id: str | None = None
+    artist_name: str | None = None
+    release_group_id: str | None = None
+
+
 class DetailResponse(BaseModel):
     """Comprehensive media details rendered on the detail page."""
 
@@ -148,6 +154,7 @@ class DetailResponse(BaseModel):
     recommended: list[DiscoverItem] | None = None
     links: DetailLinks | None = None
     availability: AvailabilityInfo | None = None
+    musicbrainz: MusicBrainzInfo | None = None
 
 
 class CapabilitiesResponse(BaseModel):

--- a/apps/api/app/services/discovery_apple.py
+++ b/apps/api/app/services/discovery_apple.py
@@ -1,0 +1,34 @@
+from typing import Dict, List
+
+import httpx
+
+BASE = "https://rss.marketingtools.apple.com/api/v2"
+
+
+def apple_feed(
+    storefront: str,
+    genre_id: int,
+    feed: str = "most-recent",
+    kind: str = "albums",
+    limit: int = 50,
+) -> List[Dict[str, object]]:
+    url = f"{BASE}/{storefront}/music/{feed}/{kind}/{limit}/genre={genre_id}/json"
+    response = httpx.get(url, timeout=10)
+    response.raise_for_status()
+    results = response.json().get("feed", {}).get("results", [])
+    items: List[Dict[str, object]] = []
+    for entry in results:
+        items.append(
+            {
+                "id": entry.get("id"),
+                "title": entry.get("name"),
+                "artist": entry.get("artistName"),
+                "url": entry.get("url"),
+                "artwork": entry.get("artworkUrl100"),
+                "releaseDate": entry.get("releaseDate"),
+            }
+        )
+    return items
+
+
+__all__ = ["apple_feed"]

--- a/apps/api/app/services/discovery_genres.py
+++ b/apps/api/app/services/discovery_genres.py
@@ -1,0 +1,15 @@
+CURATED = [
+    {"key": "techno", "label": "Techno", "appleGenreId": 718},
+    {"key": "house", "label": "House", "appleGenreId": 1250},
+    {"key": "dnb", "label": "Drum & Bass", "appleGenreId": 1253},
+    {"key": "ambient", "label": "Ambient", "appleGenreId": 502},
+    {"key": "rock", "label": "Rock", "appleGenreId": 21},
+    {"key": "pop", "label": "Pop", "appleGenreId": 14},
+    {"key": "hip-hop", "label": "Hip-Hop", "appleGenreId": 18},
+    {"key": "jazz", "label": "Jazz", "appleGenreId": 11},
+    {"key": "metal", "label": "Metal", "appleGenreId": 1153},
+    {"key": "indie", "label": "Indie", "appleGenreId": 20},
+    {"key": "classical", "label": "Classical", "appleGenreId": 5},
+]
+
+__all__ = ["CURATED"]

--- a/apps/api/app/services/discovery_lb.py
+++ b/apps/api/app/services/discovery_lb.py
@@ -1,0 +1,31 @@
+from typing import Dict, List
+
+import httpx
+
+LB_URL = "https://labs.api.listenbrainz.org/similar-artists/json"
+
+
+def similar_artists(artist_mbid: str, limit: int = 20) -> List[Dict[str, object]]:
+    response = httpx.get(
+        LB_URL,
+        params={
+            "artist_mbid": artist_mbid,
+            "algorithm": "session_based_days_7500_session_300_contribution_5_threshold_10_limit_100_filter_True_skip_30",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    artists = response.json().get("similar_artists", [])
+    items: List[Dict[str, object]] = []
+    for entry in artists[:limit]:
+        items.append(
+            {
+                "mbid": entry.get("artist_mbid"),
+                "name": entry.get("artist_name"),
+                "score": entry.get("score"),
+            }
+        )
+    return items
+
+
+__all__ = ["similar_artists"]

--- a/apps/api/app/services/discovery_mb.py
+++ b/apps/api/app/services/discovery_mb.py
@@ -1,0 +1,58 @@
+import datetime as dt
+import time
+from typing import Dict, List
+
+import httpx
+
+UA = "Phelia/1.0 (contact: admin@example.com)"
+BASE = "https://musicbrainz.org/ws/2"
+
+
+def _get(path: str, params: Dict[str, str], timeout: int = 12) -> dict:
+    for attempt in range(3):
+        response = httpx.get(
+            f"{BASE}/{path}",
+            params=params,
+            headers={"User-Agent": UA},
+            timeout=timeout,
+        )
+        if response.status_code in (503, 429):
+            time.sleep(1.5 * (attempt + 1))
+            continue
+        response.raise_for_status()
+        return response.json()
+    response.raise_for_status()
+
+
+def new_releases_by_genre(genre: str, days: int = 30, limit: int = 50) -> List[Dict[str, object]]:
+    end = dt.date.today()
+    start = end - dt.timedelta(days=days)
+    query = (
+        "primarytype:album AND status:official "
+        f"AND firstreleasedate:[{start.isoformat()} TO {end.isoformat()}] "
+        f'AND tag:"{genre}"'
+    )
+    data = _get("release-group", {"query": query, "fmt": "json", "limit": str(limit)})
+    items: List[Dict[str, object]] = []
+    for release_group in data.get("release-groups", []):
+        credits = release_group.get("artist-credit", [])
+        artists: List[str] = []
+        for credit in credits:
+            if isinstance(credit, dict):
+                name = credit.get("name")
+                if name:
+                    artists.append(str(name))
+        items.append(
+            {
+                "mbid": release_group.get("id"),
+                "title": release_group.get("title"),
+                "artist": " & ".join(artists),
+                "firstReleaseDate": release_group.get("first-release-date"),
+                "primaryType": release_group.get("primary-type"),
+                "secondaryTypes": release_group.get("secondary-types") or [],
+            }
+        )
+    return items
+
+
+__all__ = ["new_releases_by_genre"]

--- a/apps/web/src/app/__tests__/BrowsePage.test.tsx
+++ b/apps/web/src/app/__tests__/BrowsePage.test.tsx
@@ -1,0 +1,156 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import BrowsePage from '@/app/routes/browse';
+import { renderWithProviders } from '@/app/test-utils';
+
+const { toastErrorMock, toastMock } = vi.hoisted(() => {
+  const toastErrorMock = vi.fn();
+  const toastMock = { error: toastErrorMock } as const;
+  return { toastErrorMock, toastMock };
+});
+
+vi.mock('sonner', () => ({
+  toast: toastMock,
+}));
+
+describe('BrowsePage', () => {
+  const fetchMock = vi.fn();
+
+  function createResponse(data: unknown, ok = true, status = 200) {
+    return Promise.resolve({
+      ok,
+      status,
+      json: async () => data,
+    } as Response);
+  }
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    toastErrorMock.mockReset();
+    global.fetch = fetchMock;
+  });
+
+  it('renders curated genres', async () => {
+    fetchMock.mockImplementation((input: RequestInfo) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/genres')) {
+        return createResponse({
+          genres: [
+            { key: 'techno', label: 'Techno', appleGenreId: 1 },
+            { key: 'house', label: 'House', appleGenreId: 2 },
+          ],
+        });
+      }
+      return createResponse({ items: [] });
+    });
+
+    renderWithProviders(<BrowsePage />);
+
+    expect(await screen.findByRole('button', { name: /techno/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /house/i })).toBeInTheDocument();
+  });
+
+  it('loads rails when selecting a genre', async () => {
+    const user = userEvent.setup();
+    const calls: string[] = [];
+    fetchMock.mockImplementation((input: RequestInfo) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      calls.push(url);
+      if (url.includes('/genres')) {
+        return createResponse({
+          genres: [
+            { key: 'techno', label: 'Techno', appleGenreId: 1 },
+            { key: 'ambient', label: 'Ambient', appleGenreId: 2 },
+          ],
+        });
+      }
+      if (url.includes('/new')) {
+        const params = new URL(url, 'http://localhost');
+        if (params.searchParams.get('genre') === 'ambient') {
+          return createResponse({
+            items: [
+              {
+                mbid: 'mb2',
+                title: 'Deep Drift',
+                artist: 'Atmos Duo',
+                firstReleaseDate: '2024-05-01',
+                primaryType: 'Album',
+                secondaryTypes: ['Live'],
+              },
+            ],
+          });
+        }
+        return createResponse({ items: [] });
+      }
+      if (url.includes('/top')) {
+        const params = new URL(url, 'http://localhost');
+        if (params.searchParams.get('genre_id') === '2') {
+          return createResponse({
+            items: [
+              {
+                id: 'apple1',
+                title: 'Ambient Flow',
+                artist: 'Sky City',
+                artwork: 'https://example.com/art.jpg',
+                releaseDate: '2024-04-20',
+              },
+            ],
+          });
+        }
+        return createResponse({ items: [] });
+      }
+      return createResponse({ items: [] });
+    });
+
+    renderWithProviders(<BrowsePage />);
+
+    const ambientButton = await screen.findByRole('button', { name: /ambient/i });
+    await user.click(ambientButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Deep Drift')).toBeInTheDocument();
+      expect(screen.getByText('Ambient Flow')).toBeInTheDocument();
+    });
+
+    expect(calls.some((url) => url.includes('/new?genre=ambient'))).toBe(true);
+    expect(calls.some((url) => url.includes('/top'))).toBe(true);
+  });
+
+  it('shows toasts on fetch errors but keeps UI responsive', async () => {
+    fetchMock.mockImplementation((input: RequestInfo) => {
+      const url = typeof input === 'string' ? input : (input as Request).url;
+      if (url.includes('/genres')) {
+        return createResponse({
+          genres: [{ key: 'rock', label: 'Rock', appleGenreId: 21 }],
+        });
+      }
+      if (url.includes('/new')) {
+        return createResponse({ message: 'upstream error' }, false, 502);
+      }
+      if (url.includes('/top')) {
+        return createResponse({
+          items: [
+            {
+              id: 'apple42',
+              title: 'Guitar Echoes',
+              artist: 'Ampersand',
+              releaseDate: '2024-03-01',
+            },
+          ],
+        });
+      }
+      return createResponse({ items: [] });
+    });
+
+    renderWithProviders(<BrowsePage />);
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith('Unable to load new releases.');
+    });
+
+    const headers = await screen.findAllByText(/Most Recent/i);
+    expect(headers.length).toBeGreaterThan(0);
+    expect(screen.queryByText('Guitar Echoes')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/components/Sidebar.tsx
+++ b/apps/web/src/app/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { NavLink } from 'react-router-dom';
-import { Film, Home, Bookmark, Music2, Settings, Tv, Download } from 'lucide-react';
+import { Bookmark, Compass, Download, Film, Home, Music2, Settings, Tv } from 'lucide-react';
 import { Button } from '@/app/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/app/components/ui/tooltip';
 import { useUiState } from '@/app/stores/ui';
@@ -8,6 +8,7 @@ import { cn } from '@/app/utils/cn';
 
 const NAV_ITEMS = [
   { to: '/', label: 'Home', icon: Home },
+  { to: '/browse', label: 'Browse', icon: Compass },
   { to: '/movies', label: 'Movies', icon: Film },
   { to: '/tv', label: 'TV Shows', icon: Tv },
   { to: '/music', label: 'Music', icon: Music2 },

--- a/apps/web/src/app/lib/discovery.ts
+++ b/apps/web/src/app/lib/discovery.ts
@@ -1,0 +1,60 @@
+export interface DiscoveryGenre {
+  key: string;
+  label: string;
+  appleGenreId: number;
+}
+
+async function parseJson(response: Response) {
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function getGenres(): Promise<DiscoveryGenre[]> {
+  const response = await fetch('/api/v1/discovery/genres');
+  const data = await parseJson(response);
+  return Array.isArray(data?.genres) ? data.genres : [];
+}
+
+export async function getNew(genre: string, days = 30, limit = 50) {
+  const params = new URLSearchParams({
+    genre,
+    days: String(days),
+    limit: String(limit),
+  });
+  const response = await fetch(`/api/v1/discovery/new?${params.toString()}`);
+  const data = await parseJson(response);
+  return Array.isArray(data?.items) ? data.items : [];
+}
+
+export async function getTop(
+  genreId: number,
+  feed = 'most-recent',
+  kind = 'albums',
+  limit = 50,
+  storefront?: string,
+) {
+  const params = new URLSearchParams({
+    feed,
+    kind,
+    limit: String(limit),
+    genre_id: String(genreId),
+  });
+  if (storefront) {
+    params.append('storefront', storefront);
+  }
+  const response = await fetch(`/api/v1/discovery/top?${params.toString()}`);
+  const data = await parseJson(response);
+  return Array.isArray(data?.items) ? data.items : [];
+}
+
+export async function getSimilarArtists(artistMbid: string, limit = 20) {
+  const params = new URLSearchParams({
+    artist_mbid: artistMbid,
+    limit: String(limit),
+  });
+  const response = await fetch(`/api/v1/discovery/similar-artists?${params.toString()}`);
+  const data = await parseJson(response);
+  return Array.isArray(data?.items) ? data.items : [];
+}

--- a/apps/web/src/app/lib/types.ts
+++ b/apps/web/src/app/lib/types.ts
@@ -128,6 +128,19 @@ export interface DetailResponse {
     external?: ExternalLink[];
   };
   availability?: AvailabilityInfo;
+  musicbrainz?: MusicBrainzInfo | null;
+}
+
+export interface MusicBrainzInfo {
+  artist_id?: string | null;
+  artist_name?: string | null;
+  release_group_id?: string | null;
+}
+
+export interface SimilarArtist {
+  mbid?: string | null;
+  name?: string | null;
+  score?: number | null;
 }
 
 export interface SearchParams {

--- a/apps/web/src/app/routes/AppRoutes.tsx
+++ b/apps/web/src/app/routes/AppRoutes.tsx
@@ -9,6 +9,7 @@ const HomePage = lazy(() => import('@/app/routes/index'));
 const MoviesPage = lazy(() => import('@/app/routes/movies'));
 const TvPage = lazy(() => import('@/app/routes/tv'));
 const MusicPage = lazy(() => import('@/app/routes/music'));
+const BrowsePage = lazy(() => import('@/app/routes/browse'));
 const LibraryPage = lazy(() => import('@/app/routes/library'));
 const DownloadsPage = lazy(() => import('@/app/routes/downloads'));
 const SettingsPage = lazy(() => import('@/app/routes/settings'));
@@ -24,6 +25,7 @@ function AppRoutes() {
         <Routes location={state?.backgroundLocation ?? location}>
           <Route element={<AppShell />}>
             <Route index element={<HomePage />} />
+            <Route path="browse" element={<BrowsePage />} />
             <Route path="movies" element={<MoviesPage />} />
             <Route path="tv" element={<TvPage />} />
             <Route path="music" element={<MusicPage />} />

--- a/apps/web/src/app/routes/browse.tsx
+++ b/apps/web/src/app/routes/browse.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import RecommendationsRail from '@/app/components/Rails/RecommendationsRail';
+import { Badge } from '@/app/components/ui/badge';
+import { Skeleton } from '@/app/components/ui/skeleton';
+import type { DiscoverItem } from '@/app/lib/types';
+import { getGenres, getNew, getTop } from '@/app/lib/discovery';
+import type { DiscoveryGenre } from '@/app/lib/discovery';
+
+const DEFAULT_DAYS = 30;
+const DEFAULT_LIMIT = 50;
+
+type MusicBrainzRelease = {
+  mbid?: string;
+  title?: string;
+  artist?: string;
+  firstReleaseDate?: string;
+  primaryType?: string;
+  secondaryTypes?: string[];
+};
+
+type AppleFeedItem = {
+  id?: string;
+  title?: string;
+  artist?: string;
+  url?: string;
+  artwork?: string;
+  releaseDate?: string;
+};
+
+function parseYear(value?: string | null): number | undefined {
+  if (!value) return undefined;
+  const year = Number.parseInt(value.slice(0, 4), 10);
+  return Number.isFinite(year) ? year : undefined;
+}
+
+function mapMusicBrainzItem(item: MusicBrainzRelease, genreLabel: string): DiscoverItem {
+  const badges: string[] = [];
+  if (item.primaryType) {
+    badges.push(item.primaryType);
+  }
+  if (Array.isArray(item.secondaryTypes) && item.secondaryTypes.length) {
+    badges.push(...item.secondaryTypes);
+  }
+  return {
+    kind: 'album',
+    id: item.mbid || `mb:${item.title ?? 'unknown'}:${item.artist ?? 'various'}`,
+    title: item.title ?? 'Untitled Release',
+    subtitle: item.artist ?? genreLabel,
+    year: parseYear(item.firstReleaseDate),
+    badges,
+    meta: {
+      source: 'musicbrainz',
+      mbid: item.mbid,
+      firstReleaseDate: item.firstReleaseDate,
+      primaryType: item.primaryType,
+      secondaryTypes: item.secondaryTypes,
+    },
+  };
+}
+
+function mapAppleItem(item: AppleFeedItem): DiscoverItem {
+  return {
+    kind: 'album',
+    id: item.id ?? `apple:${item.title ?? 'unknown'}:${item.artist ?? 'various'}`,
+    title: item.title ?? 'Untitled Album',
+    subtitle: item.artist ?? undefined,
+    poster: item.artwork ?? undefined,
+    year: parseYear(item.releaseDate),
+    meta: {
+      source: 'apple',
+      url: item.url,
+      releaseDate: item.releaseDate,
+    },
+  };
+}
+
+function GenreButton({ genre, active, onSelect }: { genre: DiscoveryGenre; active: boolean; onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={active}
+      className={`group flex flex-col justify-between rounded-3xl border p-4 text-left transition hover:border-[color:var(--accent)] hover:shadow-glow ${
+        active ? 'border-[color:var(--accent)] bg-[color:var(--accent)]/10 text-foreground' : 'border-border/60 text-muted-foreground'
+      }`}
+    >
+      <span className="text-lg font-semibold text-foreground">{genre.label}</span>
+      <span className="mt-2 text-xs uppercase tracking-wide text-muted-foreground">
+        {genre.key.replace(/-/g, ' ')}
+      </span>
+    </button>
+  );
+}
+
+function BrowsePage() {
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const genresQuery = useQuery({
+    queryKey: ['discovery', 'genres'],
+    queryFn: getGenres,
+    staleTime: 12 * 60 * 60 * 1000,
+  });
+
+  const genres = genresQuery.data ?? [];
+
+  useEffect(() => {
+    if (!selectedKey && genres.length) {
+      setSelectedKey(genres[0]?.key ?? null);
+    }
+  }, [genres, selectedKey]);
+
+  useEffect(() => {
+    if (genresQuery.error) {
+      toast.error('Unable to load genres.');
+    }
+  }, [genresQuery.error]);
+
+  const selectedGenre = useMemo<DiscoveryGenre | null>(
+    () => genres.find((genre) => genre.key === selectedKey) ?? null,
+    [genres, selectedKey],
+  );
+
+  const newReleasesQuery = useQuery({
+    queryKey: ['discovery', 'new', selectedGenre?.key, DEFAULT_DAYS, DEFAULT_LIMIT],
+    queryFn: () => getNew(selectedGenre!.key, DEFAULT_DAYS, DEFAULT_LIMIT),
+    enabled: Boolean(selectedGenre?.key),
+    select: (items: MusicBrainzRelease[]) =>
+      items.map((item) => mapMusicBrainzItem(item, selectedGenre?.label ?? '')),
+    staleTime: 3 * 60 * 60 * 1000,
+  });
+
+  const mostRecentQuery = useQuery({
+    queryKey: ['discovery', 'top', selectedGenre?.appleGenreId, DEFAULT_LIMIT],
+    queryFn: () => getTop(selectedGenre!.appleGenreId, 'most-recent', 'albums', DEFAULT_LIMIT),
+    enabled: Boolean(selectedGenre?.appleGenreId),
+    select: (items: AppleFeedItem[]) => items.map((item) => mapAppleItem(item)),
+    staleTime: 3 * 60 * 60 * 1000,
+  });
+
+  useEffect(() => {
+    if (newReleasesQuery.error) {
+      toast.error('Unable to load new releases.');
+    }
+  }, [newReleasesQuery.error]);
+
+  useEffect(() => {
+    if (mostRecentQuery.error) {
+      toast.error('Unable to load most recent releases.');
+    }
+  }, [mostRecentQuery.error]);
+
+  return (
+    <div className="space-y-10">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-foreground">Browse</h1>
+        <p className="text-sm text-muted-foreground">Discover new releases and trending albums by genre.</p>
+      </header>
+
+      <section className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">Genres</h2>
+          {selectedGenre ? (
+            <Badge variant="outline" className="bg-background/60 text-xs uppercase tracking-wide">
+              {selectedGenre.label}
+            </Badge>
+          ) : null}
+        </div>
+        {genresQuery.isLoading ? (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-24 rounded-3xl" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {genres.map((genre) => (
+              <GenreButton
+                key={genre.key}
+                genre={genre}
+                active={genre.key === selectedKey}
+                onSelect={() => setSelectedKey(genre.key)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {selectedGenre ? (
+        <div className="space-y-10">
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-foreground">New Releases</h3>
+              <span className="text-xs text-muted-foreground">MusicBrainz • Last {DEFAULT_DAYS} days</span>
+            </div>
+            {newReleasesQuery.isLoading ? (
+              <Skeleton className="h-52 w-full rounded-3xl" />
+            ) : (
+              <>
+                <RecommendationsRail title="New Releases" items={newReleasesQuery.data ?? []} />
+                {!newReleasesQuery.isLoading && !(newReleasesQuery.data?.length ?? 0) ? (
+                  <p className="text-sm text-muted-foreground">No recent releases found for this genre.</p>
+                ) : null}
+              </>
+            )}
+          </section>
+
+          <section className="space-y-3">
+            <div className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-foreground">Most Recent</h3>
+              <span className="text-xs text-muted-foreground">Apple Music RSS</span>
+            </div>
+            {mostRecentQuery.isLoading ? (
+              <Skeleton className="h-52 w-full rounded-3xl" />
+            ) : (
+              <>
+                <RecommendationsRail title="Most Recent" items={mostRecentQuery.data ?? []} />
+                {!mostRecentQuery.isLoading && !(mostRecentQuery.data?.length ?? 0) ? (
+                  <p className="text-sm text-muted-foreground">No trending releases available.</p>
+                ) : null}
+              </>
+            )}
+          </section>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default BrowsePage;

--- a/apps/web/src/app/routes/settings.tsx
+++ b/apps/web/src/app/routes/settings.tsx
@@ -114,7 +114,7 @@ function SettingsPage() {
       }
       return parsed.toString();
     } catch {
-      const protocol = window.location.protocol || 'http:'\;
+      const protocol = window.location.protocol || 'http:';
       const hostname = window.location.hostname || 'localhost';
       return `${protocol}//${hostname}:9117`;
     }


### PR DESCRIPTION
## Summary
- add server-side discovery services for MusicBrainz, Apple RSS, and ListenBrainz with Redis caching
- expose `/api/v1/discovery` routes and extend detail responses with MusicBrainz metadata
- build a Browse page with genre cards and discovery rails plus similar-artist UI support

## Testing
- pytest
- npm test