### PR TITLE
feat: add metadata proxy service and client integration

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -68,6 +68,8 @@ class Settings(BaseSettings):
     # We ship a sensible default that complies with their etiquette.
     MB_USER_AGENT: str = "Phelia/0.1 (https://example.local)"
 
+    METADATA_BASE_URL: AnyHttpUrl | None = None
+
     class Config:
         extra = "ignore"
 
@@ -78,3 +80,6 @@ except ValidationError as e:
     raise RuntimeError(
         f"Missing required configuration variables: {missing}"
     ) from e
+
+if settings.METADATA_BASE_URL is None:
+    raise RuntimeError("METADATA_BASE_URL is required")

--- a/apps/api/app/services/metadata/__init__.py
+++ b/apps/api/app/services/metadata/__init__.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.core.runtime_settings import runtime_settings
 
 from .classifier import Classifier
+from .metadata_client import MetadataClient, get_metadata_client
 from .router import MetadataRouter
 from .providers.tmdb import TMDBClient
 from .providers.omdb import OMDbClient
@@ -35,4 +36,14 @@ def get_metadata_router() -> MetadataRouter:
         discogs_client=discogs_client,
         lastfm_client=lastfm_client,
     )
+
+
+__all__ = [
+    "Classifier",
+    "MetadataRouter",
+    "MetadataClient",
+    "get_classifier",
+    "get_metadata_router",
+    "get_metadata_client",
+]
 

--- a/apps/api/app/services/metadata/metadata_client.py
+++ b/apps/api/app/services/metadata/metadata_client.py
@@ -1,0 +1,75 @@
+"""HTTP client for the internal metadata proxy service."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+
+class MetadataProxyError(Exception):
+    """Raised when the metadata proxy returns an error payload."""
+
+    def __init__(self, status_code: int, detail: Any) -> None:
+        super().__init__(f"metadata proxy error: {status_code}")
+        self.status_code = status_code
+        self.detail = detail
+
+
+class MetadataClient:
+    """Lightweight async client for the metadata proxy."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self.base_url = base_url.rstrip("/")
+        self._timeout = httpx.Timeout(timeout, connect=3.0, read=timeout, write=timeout)
+        self._limits = httpx.Limits(max_connections=10, max_keepalive_connections=5)
+
+    async def _get(
+        self,
+        provider: str,
+        path: str,
+        params: dict[str, Any] | None,
+        request_id: str | None,
+    ) -> Any:
+        url = f"{self.base_url}/{provider}/{path.lstrip('/')}"
+        headers = {"accept": "application/json"}
+        if request_id:
+            headers["x-request-id"] = request_id
+        async with httpx.AsyncClient(timeout=self._timeout, limits=self._limits) as client:
+            response = await client.get(url, params=params or {}, headers=headers)
+        if response.status_code >= 400:
+            detail = self._extract_error(response)
+            raise MetadataProxyError(response.status_code, detail)
+        return response.json()
+
+    @staticmethod
+    def _extract_error(response: httpx.Response) -> Any:
+        try:
+            payload = response.json()
+        except ValueError:  # pragma: no cover - defensive
+            payload = response.text
+        if isinstance(payload, dict) and "detail" in payload:
+            return payload["detail"]
+        return payload
+
+    async def tmdb(self, path: str, params: dict[str, Any] | None = None, *, request_id: str | None = None) -> Any:
+        return await self._get("tmdb", path, params, request_id)
+
+    async def lastfm(self, path: str, params: dict[str, Any] | None = None, *, request_id: str | None = None) -> Any:
+        return await self._get("lastfm", path, params, request_id)
+
+    async def mb(self, path: str, params: dict[str, Any] | None = None, *, request_id: str | None = None) -> Any:
+        return await self._get("mb", path, params, request_id)
+
+    async def fanart(self, path: str, params: dict[str, Any] | None = None, *, request_id: str | None = None) -> Any:
+        return await self._get("fanart", path, params, request_id)
+
+
+@lru_cache
+def get_metadata_client() -> MetadataClient:
+    if not settings.METADATA_BASE_URL:
+        raise RuntimeError("METADATA_BASE_URL is not configured")
+    return MetadataClient(str(settings.METADATA_BASE_URL))

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -12,6 +12,7 @@ os.environ.setdefault("QB_URL", "http://localhost:8080")
 os.environ.setdefault("QB_USER", "admin")
 os.environ.setdefault("QB_PASS", "adminadmin")
 os.environ.setdefault("ANYIO_BACKEND", "asyncio")
+os.environ.setdefault("METADATA_BASE_URL", "http://metadata-proxy:8080")
 
 # Add apps/api to path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -53,6 +53,7 @@ services:
       CELERY_RESULT_BACKEND: redis://redis:6379/1
       QB_URL: http://qbittorrent:8080
       TZ: ${TZ:-Etc/UTC}
+      METADATA_BASE_URL: http://metadata-proxy:8080
     command: ["/app/entrypoint.sh"]
     depends_on:
       db:
@@ -60,6 +61,8 @@ services:
       redis:
         condition: service_healthy
       qbittorrent:
+        condition: service_healthy
+      metadata-proxy:
         condition: service_healthy
     volumes:
       - ../apps/api:/app
@@ -155,3 +158,13 @@ volumes:
   downloads:
   music:
 
+  metadata-proxy:
+    build:
+      context: ../services/metadata-proxy
+    env_file:
+      - ./.env
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5

--- a/services/metadata-proxy/Dockerfile
+++ b/services/metadata-proxy/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN adduser --disabled-password --gecos "" appuser
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+USER appuser
+
+EXPOSE 8080
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/metadata-proxy/app/__init__.py
+++ b/services/metadata-proxy/app/__init__.py
@@ -1,0 +1,5 @@
+"""Phelia Metadata Proxy service."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/services/metadata-proxy/app/cache.py
+++ b/services/metadata-proxy/app/cache.py
@@ -1,0 +1,157 @@
+"""Caching utilities for the metadata proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - optional dependency
+    import redis.asyncio as redis
+except ImportError:  # pragma: no cover - fallback for legacy aioredis package
+    redis = None  # type: ignore
+
+from .config import Settings
+
+
+class CacheBackend(ABC):
+    """Abstract cache interface."""
+
+    @abstractmethod
+    async def get(self, key: str) -> bytes | None:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def set(self, key: str, value: bytes, ttl: int) -> None:
+        raise NotImplementedError
+
+    async def close(self) -> None:  # pragma: no cover - optional override
+        return None
+
+
+class MemoryCache(CacheBackend):
+    """Simple in-memory cache suitable for development."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, tuple[float, bytes]] = {}
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> bytes | None:
+        async with self._lock:
+            entry = self._store.get(key)
+            if not entry:
+                return None
+            expires_at, payload = entry
+            if expires_at and expires_at < time.monotonic():
+                self._store.pop(key, None)
+                return None
+            return payload
+
+    async def set(self, key: str, value: bytes, ttl: int) -> None:
+        async with self._lock:
+            expires_at = time.monotonic() + ttl if ttl else 0
+            self._store[key] = (expires_at, value)
+
+
+class SQLiteCache(CacheBackend):
+    """SQLite-backed cache for lightweight deployments."""
+
+    def __init__(self, path: str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._path, check_same_thread=False)
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cache (
+                key TEXT PRIMARY KEY,
+                value BLOB NOT NULL,
+                expires_at REAL NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_cache_exp ON cache (expires_at)")
+        self._conn.commit()
+        self._lock = asyncio.Lock()
+
+    async def get(self, key: str) -> bytes | None:
+        async with self._lock:
+            now = time.time()
+            cursor = self._conn.execute(
+                "SELECT value, expires_at FROM cache WHERE key = ?", (key,)
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            value, expires_at = row
+            if expires_at and expires_at < now:
+                self._conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                self._conn.commit()
+                return None
+            return value
+
+    async def set(self, key: str, value: bytes, ttl: int) -> None:
+        async with self._lock:
+            expires_at = time.time() + ttl if ttl else time.time()
+            self._conn.execute(
+                "REPLACE INTO cache (key, value, expires_at) VALUES (?, ?, ?)",
+                (key, value, expires_at),
+            )
+            self._conn.commit()
+
+    async def close(self) -> None:
+        self._conn.close()
+
+
+class RedisCache(CacheBackend):
+    """Redis-backed cache leveraging redis-py asyncio support."""
+
+    def __init__(self, url: str) -> None:
+        if not redis:  # pragma: no cover - defensive
+            raise RuntimeError("redis dependency not available")
+        self._client = redis.from_url(url, encoding="utf-8", decode_responses=False)
+
+    async def get(self, key: str) -> bytes | None:
+        value = await self._client.get(key)
+        if value is None:
+            return None
+        return value if isinstance(value, (bytes, bytearray)) else bytes(value)
+
+    async def set(self, key: str, value: bytes, ttl: int) -> None:
+        await self._client.set(name=key, value=value, ex=ttl or None)
+
+    async def close(self) -> None:
+        await self._client.close()
+
+
+_cache_backend: CacheBackend | None = None
+
+
+async def init_cache(settings: Settings) -> CacheBackend:
+    global _cache_backend
+    if _cache_backend is not None:
+        return _cache_backend
+
+    backend = settings.cache_backend.lower()
+    if backend == "memory":
+        _cache_backend = MemoryCache()
+    elif backend == "redis":
+        if not settings.redis_url:
+            raise RuntimeError("REDIS_URL must be set when CACHE_BACKEND=redis")
+        _cache_backend = RedisCache(settings.redis_url)
+    else:
+        _cache_backend = SQLiteCache(settings.sqlite_cache_path)
+    return _cache_backend
+
+
+def get_cache() -> CacheBackend:
+    if _cache_backend is None:
+        raise RuntimeError("Cache backend not initialised")
+    return _cache_backend
+
+
+async def close_cache() -> None:
+    if _cache_backend is not None:
+        await _cache_backend.close()

--- a/services/metadata-proxy/app/clients/__init__.py
+++ b/services/metadata-proxy/app/clients/__init__.py
@@ -1,0 +1,185 @@
+"""Common provider routing helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Iterable, Mapping
+from urllib.parse import urlencode, urljoin
+
+import httpx
+import orjson
+from fastapi import APIRouter, HTTPException, Request
+
+from ..cache import CacheBackend, get_cache
+from ..config import Settings, get_settings
+from ..http import request_json
+from ..ratelimit import TokenBucket
+from ..schemas import ProxyPayload
+
+logger = logging.getLogger(__name__)
+
+ParamBuilder = Callable[[Request, str, Settings], list[tuple[str, str]]]
+HeaderBuilder = Callable[[Request, str, Settings], Mapping[str, str]]
+
+
+@dataclass
+class ProviderConfig:
+    name: str
+    base_url: str
+    ttl: int
+    build_params: ParamBuilder
+    build_headers: HeaderBuilder
+
+
+def _default_headers(_: Request, __: str, ___: Settings) -> Mapping[str, str]:
+    return {"accept": "application/json"}
+
+
+def _cache_key(url: str, params: Iterable[tuple[str, str]]) -> str:
+    encoded = urlencode(sorted(params)) if params else ""
+    return f"{url}?{encoded}" if encoded else url
+
+
+async def _ensure_cache() -> CacheBackend:
+    return get_cache()
+
+
+async def proxy_request(
+    request: Request,
+    path: str,
+    config: ProviderConfig,
+    *,
+    rate_limiter: TokenBucket,
+    settings: Settings,
+) -> ProxyPayload:
+    await rate_limiter.acquire()
+
+    upstream_url = urljoin(str(config.base_url), path)
+    query_items = list(request.query_params.multi_items())
+    extra_params = config.build_params(request, path, settings)
+    params = query_items + extra_params
+    cache_key = _cache_key(upstream_url, params)
+
+    cache = await _ensure_cache()
+    cached_blob = await cache.get(cache_key)
+    if cached_blob:
+        cached_payload = orjson.loads(cached_blob)
+        data = cached_payload["data"]
+        fetched_at = datetime.fromisoformat(cached_payload["fetched_at"])  # type: ignore[arg-type]
+        logger.info(
+            json.dumps(
+                {
+                    "event": "proxy_fetch",
+                    "provider": config.name,
+                    "status": 200,
+                    "cached": True,
+                    "latency_ms": 0,
+                    "request_id": request.headers.get("x-request-id"),
+                    "endpoint": path,
+                }
+            )
+        )
+        return ProxyPayload(
+            provider=config.name,
+            cached=True,
+            fetched_at=fetched_at,
+            data=_attach_metadata(data, config.name, True, fetched_at),
+        )
+
+    headers = dict(config.build_headers(request, path, settings))
+    request_id = request.headers.get("x-request-id")
+    if request_id:
+        headers.setdefault("x-request-id", request_id)
+
+    start = time.perf_counter()
+    response = await request_json(
+        "GET", upstream_url, params=httpx.QueryParams(params), headers=headers
+    )
+    latency = time.perf_counter() - start
+
+    if response.status_code >= 400:
+        message = response.text
+        logger.warning(
+            json.dumps(
+                {
+                    "event": "proxy_error",
+                    "provider": config.name,
+                    "status": response.status_code,
+                    "request_id": request_id,
+                    "latency_ms": round(latency * 1000, 2),
+                }
+            )
+        )
+        raise HTTPException(
+            status_code=response.status_code,
+            detail={
+                "error": "upstream_error",
+                "status": response.status_code,
+                "upstream_status": response.status_code,
+                "request_id": request_id,
+                "message": message,
+            },
+        )
+
+    fetched_at = datetime.now(timezone.utc)
+    payload = response.json()
+    body = _attach_metadata(payload, config.name, False, fetched_at)
+
+    cache_control = response.headers.get("cache-control", "").lower()
+    if "no-store" not in cache_control:
+        stored = orjson.dumps({"data": payload, "fetched_at": fetched_at.isoformat()})
+        await cache.set(cache_key, stored, config.ttl)
+
+    logger.info(
+        json.dumps(
+            {
+                "event": "proxy_fetch",
+                "provider": config.name,
+                "status": response.status_code,
+                "cached": False,
+                "latency_ms": round(latency * 1000, 2),
+                "request_id": request_id,
+                "endpoint": path,
+            }
+        )
+    )
+
+    return ProxyPayload(provider=config.name, cached=False, fetched_at=fetched_at, data=body)
+
+
+def _attach_metadata(data: object, provider: str, cached: bool, fetched_at: datetime) -> object:
+    if isinstance(data, dict):
+        data = dict(data)
+        data.setdefault("provider", provider)
+        data.setdefault("cached", cached)
+        data.setdefault("fetched_at", fetched_at.isoformat())
+        return data
+    return {
+        "provider": provider,
+        "cached": cached,
+        "fetched_at": fetched_at.isoformat(),
+        "data": data,
+    }
+
+
+def create_router(config: ProviderConfig, rate_limiter: TokenBucket) -> APIRouter:
+    router = APIRouter()
+
+    settings = get_settings()
+
+    @router.get("/{path:path}")
+    async def handler(path: str, request: Request) -> object:
+        payload = await proxy_request(
+            request,
+            path,
+            config,
+            rate_limiter=rate_limiter,
+            settings=settings,
+        )
+        return payload.data
+
+    return router

--- a/services/metadata-proxy/app/clients/fanart.py
+++ b/services/metadata-proxy/app/clients/fanart.py
@@ -1,0 +1,36 @@
+"""Fanart.tv proxy router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..config import get_settings
+from ..ratelimit import TokenBucket
+from . import ProviderConfig, create_router
+
+FANART_TTL = 60 * 60 * 24 * 7  # 7 days
+
+
+def _fanart_params(_: Request, __: str, settings) -> list[tuple[str, str]]:
+    if not settings.fanart_api_key:
+        raise HTTPException(status_code=503, detail="fanart_not_configured")
+    return [("api_key", settings.fanart_api_key)]
+
+
+def _fanart_headers(_: Request, __: str, ___) -> dict[str, str]:
+    return {"accept": "application/json"}
+
+
+_settings = get_settings()
+_fanart_rate_limiter = TokenBucket(rate=_settings.rate_limit_rps)
+
+router: APIRouter = create_router(
+    ProviderConfig(
+        name="fanart",
+        base_url=str(_settings.fanart_base_url),
+        ttl=FANART_TTL,
+        build_params=_fanart_params,
+        build_headers=_fanart_headers,
+    ),
+    _fanart_rate_limiter,
+)

--- a/services/metadata-proxy/app/clients/lastfm.py
+++ b/services/metadata-proxy/app/clients/lastfm.py
@@ -1,0 +1,39 @@
+"""Last.fm proxy router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..config import get_settings
+from ..ratelimit import TokenBucket
+from . import ProviderConfig, create_router
+
+LASTFM_TTL = 60 * 60 * 24  # 24 hours
+
+
+def _lastfm_params(request: Request, path: str, settings) -> list[tuple[str, str]]:
+    if not settings.lastfm_api_key:
+        raise HTTPException(status_code=503, detail="lastfm_not_configured")
+    params = [("api_key", settings.lastfm_api_key), ("format", "json")]
+    if path and "method" not in request.query_params:
+        params.append(("method", path))
+    return params
+
+
+def _lastfm_headers(_: Request, __: str, ___) -> dict[str, str]:
+    return {"accept": "application/json"}
+
+
+_settings = get_settings()
+_lastfm_rate_limiter = TokenBucket(rate=_settings.rate_limit_rps)
+
+router: APIRouter = create_router(
+    ProviderConfig(
+        name="lastfm",
+        base_url=str(_settings.lastfm_base_url),
+        ttl=LASTFM_TTL,
+        build_params=_lastfm_params,
+        build_headers=_lastfm_headers,
+    ),
+    _lastfm_rate_limiter,
+)

--- a/services/metadata-proxy/app/clients/musicbrainz.py
+++ b/services/metadata-proxy/app/clients/musicbrainz.py
@@ -1,0 +1,37 @@
+"""MusicBrainz proxy router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Request
+
+from ..config import get_settings
+from ..ratelimit import TokenBucket
+from . import ProviderConfig, create_router
+
+MB_TTL = 60 * 60 * 24  # 24 hours
+
+
+def _mb_params(request: Request, _: str, __) -> list[tuple[str, str]]:
+    params = list(request.query_params.multi_items())
+    if not any(key == "fmt" for key, _ in params):
+        params.append(("fmt", "json"))
+    return params
+
+
+def _mb_headers(_: Request, __: str, settings) -> dict[str, str]:
+    return {"accept": "application/json", "user-agent": settings.mb_user_agent}
+
+
+_settings = get_settings()
+_mb_rate_limiter = TokenBucket(rate=_settings.rate_limit_rps)
+
+router: APIRouter = create_router(
+    ProviderConfig(
+        name="musicbrainz",
+        base_url=str(_settings.musicbrainz_base_url),
+        ttl=MB_TTL,
+        build_params=_mb_params,
+        build_headers=_mb_headers,
+    ),
+    _mb_rate_limiter,
+)

--- a/services/metadata-proxy/app/clients/tmdb.py
+++ b/services/metadata-proxy/app/clients/tmdb.py
@@ -1,0 +1,42 @@
+"""TMDB proxy router."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Request
+
+from ..config import get_settings
+from ..ratelimit import TokenBucket
+from . import ProviderConfig, create_router
+
+TMDB_TTL = 60 * 60 * 12  # 12 hours
+
+
+def _tmdb_params(_: Request, __: str, settings) -> list[tuple[str, str]]:
+    params: list[tuple[str, str]] = []
+    if not settings.tmdb_api_key:
+        raise HTTPException(status_code=503, detail="tmdb_not_configured")
+    params.append(("api_key", settings.tmdb_api_key))
+    return params
+
+
+def _tmdb_headers(request: Request, _: str, __) -> dict[str, str]:
+    headers = {"accept": "application/json"}
+    language = request.headers.get("accept-language")
+    if language:
+        headers["accept-language"] = language
+    return headers
+
+
+_settings = get_settings()
+_tmdb_rate_limiter = TokenBucket(rate=_settings.rate_limit_rps)
+
+router: APIRouter = create_router(
+    ProviderConfig(
+        name="tmdb",
+        base_url=str(_settings.tmdb_base_url),
+        ttl=TMDB_TTL,
+        build_params=_tmdb_params,
+        build_headers=_tmdb_headers,
+    ),
+    _tmdb_rate_limiter,
+)

--- a/services/metadata-proxy/app/config.py
+++ b/services/metadata-proxy/app/config.py
@@ -1,0 +1,40 @@
+"""Configuration for the metadata proxy."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import AnyHttpUrl, Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    tmdb_api_key: str | None = Field(default=None, env="TMDB_API_KEY")
+    lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
+    fanart_api_key: str | None = Field(default=None, env="FANART_API_KEY")
+
+    cache_backend: str = Field(default="sqlite", env="CACHE_BACKEND")
+    sqlite_cache_path: str = Field(default="/data/cache.db", env="SQLITE_CACHE_PATH")
+    redis_url: str | None = Field(default=None, env="REDIS_URL")
+
+    rate_limit_rps: float = Field(default=5.0, env="RATE_LIMIT_RPS")
+    retry_attempts: int = Field(default=3, env="RETRY_ATTEMPTS")
+    retry_backoff_base: float = Field(default=0.3, env="RETRY_BACKOFF_BASE")
+
+    tmdb_base_url: AnyHttpUrl = Field("https://api.themoviedb.org/3/", env="TMDB_BASE_URL")
+    lastfm_base_url: AnyHttpUrl = Field("https://ws.audioscrobbler.com/2.0/", env="LASTFM_BASE_URL")
+    musicbrainz_base_url: AnyHttpUrl = Field(
+        "https://musicbrainz.org/ws/2/", env="MUSICBRAINZ_BASE_URL"
+    )
+    fanart_base_url: AnyHttpUrl = Field("https://webservice.fanart.tv/v3/", env="FANART_BASE_URL")
+
+    mb_user_agent: str = Field("Phelia-Metadata-Proxy/1.0", env="MB_USER_AGENT")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()  # type: ignore[arg-type]

--- a/services/metadata-proxy/app/health.py
+++ b/services/metadata-proxy/app/health.py
@@ -1,0 +1,13 @@
+"""Health endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("", tags=["health"])
+@router.get("/", tags=["health"])
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}

--- a/services/metadata-proxy/app/http.py
+++ b/services/metadata-proxy/app/http.py
@@ -1,0 +1,115 @@
+"""HTTP client helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Mapping
+
+import httpx
+
+try:  # pragma: no cover - optional dependency during runtime
+    from tenacity import (  # type: ignore[import-untyped]
+        AsyncRetrying,
+        RetryError,
+        retry_if_exception_type,
+        stop_after_attempt,
+        wait_exponential,
+    )
+except ModuleNotFoundError:  # pragma: no cover - fallback when tenacity unavailable
+    AsyncRetrying = None  # type: ignore[assignment]
+    RetryError = Exception  # type: ignore[assignment]
+    retry_if_exception_type = stop_after_attempt = wait_exponential = None  # type: ignore[assignment]
+
+from .config import get_settings
+
+logger = logging.getLogger(__name__)
+
+_client: httpx.AsyncClient | None = None
+
+
+class UpstreamRetryError(Exception):
+    """Raised when an upstream response should trigger a retry."""
+
+    def __init__(self, response: httpx.Response) -> None:
+        self.response = response
+        super().__init__(f"upstream status {response.status_code}")
+
+
+async def get_http_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(
+            timeout=httpx.Timeout(10.0, connect=5.0, read=10.0, write=10.0),
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        )
+    return _client
+
+
+async def close_http_client() -> None:
+    global _client
+    if _client is not None:
+        await _client.aclose()
+        _client = None
+
+
+async def request_json(
+    method: str,
+    url: str,
+    *,
+    params: Mapping[str, Any] | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> httpx.Response:
+    """Perform an HTTP request with retry semantics."""
+
+    client = await get_http_client()
+    settings = get_settings()
+
+    async def _send() -> httpx.Response:
+        response = await client.request(method, url, params=params, headers=headers)
+        if response.status_code in {429} or 500 <= response.status_code < 600:
+            raise UpstreamRetryError(response)
+        return response
+
+    if AsyncRetrying is None:
+        attempts = max(1, settings.retry_attempts)
+        for attempt in range(1, attempts + 1):
+            try:
+                response = await _send()
+                return response
+            except UpstreamRetryError as exc:
+                if attempt == attempts:
+                    return exc.response
+                backoff = settings.retry_backoff_base * (2 ** (attempt - 1))
+                await asyncio.sleep(backoff)
+            except httpx.RequestError as exc:
+                if attempt == attempts:
+                    logger.warning("request error url=%s error=%s", url, exc)
+                    raise
+                backoff = settings.retry_backoff_base * (2 ** (attempt - 1))
+                await asyncio.sleep(backoff)
+        raise RuntimeError("Unreachable retry loop")  # pragma: no cover - safety
+
+    retry = AsyncRetrying(
+        reraise=True,
+        stop=stop_after_attempt(settings.retry_attempts),
+        wait=wait_exponential(multiplier=settings.retry_backoff_base, min=0.3, max=5),
+        retry=retry_if_exception_type((httpx.RequestError, UpstreamRetryError, httpx.HTTPStatusError)),
+    )
+
+    try:
+        async for attempt in retry:
+            with attempt:
+                response = await _send()
+    except RetryError as exc:  # pragma: no cover - defensive
+        last_attempt = exc.last_attempt
+        if last_attempt and isinstance(last_attempt.outcome.exception(), UpstreamRetryError):
+            return last_attempt.outcome.exception().response  # type: ignore[return-value]
+        raise
+    except UpstreamRetryError as exc:
+        return exc.response
+    except httpx.RequestError as exc:  # pragma: no cover - network issues
+        logger.warning("request error url=%s error=%s", url, exc)
+        raise
+    else:
+        return response

--- a/services/metadata-proxy/app/main.py
+++ b/services/metadata-proxy/app/main.py
@@ -1,0 +1,52 @@
+"""FastAPI application entrypoint for the metadata proxy."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from .cache import close_cache, init_cache
+from .clients.fanart import router as fanart_router
+from .clients.lastfm import router as lastfm_router
+from .clients.musicbrainz import router as musicbrainz_router
+from .clients.tmdb import router as tmdb_router
+from .config import get_settings
+from .health import router as health_router
+from .http import close_http_client
+
+logger = logging.getLogger("metadata_proxy")
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    settings = get_settings()
+    await init_cache(settings)
+    try:
+        yield
+    finally:
+        await close_cache()
+        await close_http_client()
+
+
+def create_app() -> FastAPI:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    app = FastAPI(title="Phelia Metadata Proxy", lifespan=lifespan)
+
+    app.include_router(health_router, prefix="/health")
+    app.include_router(tmdb_router, prefix="/tmdb")
+    app.include_router(lastfm_router, prefix="/lastfm")
+    app.include_router(musicbrainz_router, prefix="/mb")
+    app.include_router(fanart_router, prefix="/fanart")
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8080, factory=False)

--- a/services/metadata-proxy/app/ratelimit.py
+++ b/services/metadata-proxy/app/ratelimit.py
@@ -1,0 +1,36 @@
+"""Rate limiting primitives used by the metadata proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class TokenBucket:
+    """Simple token bucket rate limiter supporting awaitable acquire."""
+
+    rate: float
+    capacity: float | None = None
+
+    def __post_init__(self) -> None:
+        self.capacity = self.capacity or self.rate
+        self._tokens = float(self.capacity)
+        self._last_refill = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> None:
+        while True:
+            async with self._lock:
+                now = time.monotonic()
+                elapsed = now - self._last_refill
+                self._last_refill = now
+                self._tokens = min(
+                    self.capacity or self.rate, self._tokens + elapsed * self.rate
+                )
+                if self._tokens >= 1:
+                    self._tokens -= 1
+                    return
+                wait_time = (1 - self._tokens) / self.rate if self.rate > 0 else 0
+            await asyncio.sleep(max(0.0, wait_time))

--- a/services/metadata-proxy/app/schemas.py
+++ b/services/metadata-proxy/app/schemas.py
@@ -1,0 +1,22 @@
+"""Pydantic schemas exposed by the proxy."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ProxyPayload(BaseModel):
+    provider: str = Field(..., description="Upstream provider name")
+    cached: bool = Field(False, description="Whether the response originated from cache")
+    fetched_at: datetime = Field(..., description="Timestamp the payload was fetched")
+    data: Any = Field(..., description="Raw upstream JSON payload")
+
+
+class ErrorResponse(BaseModel):
+    error: str
+    status: int
+    upstream_status: int | None = None
+    request_id: str | None = None

--- a/services/metadata-proxy/requirements.txt
+++ b/services/metadata-proxy/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn[standard]
+httpx
+pydantic
+pydantic-settings
+redis
+orjson
+tenacity
+pytest

--- a/services/metadata-proxy/tests/conftest.py
+++ b/services/metadata-proxy/tests/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+import pytest
+
+os.environ.setdefault("TMDB_API_KEY", "test-key")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/services/metadata-proxy/tests/test_health.py
+++ b/services/metadata-proxy/tests/test_health.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+from contextlib import asynccontextmanager
+from httpx import ASGITransport, AsyncClient
+
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+if str(SERVICE_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVICE_DIR))
+
+
+MODULES = [
+    "app.main",
+]
+
+
+def _fresh_app():
+    for name in MODULES:
+        sys.modules.pop(name, None)
+    main = import_module("app.main")
+    return main.create_app()
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with app.router.lifespan_context(app):
+        yield
+
+
+@pytest.mark.anyio
+async def test_health_endpoint(monkeypatch):
+    monkeypatch.setenv("CACHE_BACKEND", "memory")
+    app = _fresh_app()
+    async with lifespan(app):
+        from app.cache import init_cache
+        from app.config import get_settings
+
+        await init_cache(get_settings())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            resp = await client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}

--- a/services/metadata-proxy/tests/test_tmdb_client.py
+++ b/services/metadata-proxy/tests/test_tmdb_client.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+from contextlib import asynccontextmanager
+from httpx import ASGITransport, AsyncClient
+
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+if str(SERVICE_DIR) not in sys.path:
+    sys.path.insert(0, str(SERVICE_DIR))
+
+MODULES = [
+    "app.main",
+    "app.config",
+    "app.cache",
+    "app.clients.tmdb",
+    "app.clients",
+    "app.http",
+]
+
+
+def _fresh_app():
+    for name in MODULES:
+        sys.modules.pop(name, None)
+    main = import_module("app.main")
+    return main.create_app()
+
+
+@asynccontextmanager
+async def lifespan(app):
+    async with app.router.lifespan_context(app):
+        yield
+
+
+class DummyResponse:
+    def __init__(self, payload: dict[str, object]) -> None:
+        self.status_code = 200
+        self._payload = payload
+        self.headers: dict[str, str] = {}
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+    @property
+    def text(self) -> str:
+        return "ok"
+
+
+@pytest.mark.anyio
+async def test_tmdb_proxy_caches(monkeypatch):
+    monkeypatch.setenv("CACHE_BACKEND", "memory")
+    monkeypatch.setenv("TMDB_API_KEY", "dummy-key")
+
+    calls = {"count": 0}
+
+    app = _fresh_app()
+    from app.config import get_settings
+    import app.clients.tmdb as tmdb_module
+
+    get_settings.cache_clear()
+    assert get_settings().tmdb_api_key == "dummy-key"
+    assert tmdb_module._settings.tmdb_api_key == "dummy-key"
+
+    async def fake_request_json(method, url, params=None, headers=None):
+        calls["count"] += 1
+        return DummyResponse({"id": 1, "title": "Example"})
+
+    monkeypatch.setattr("app.http.request_json", fake_request_json)
+    monkeypatch.setattr("app.clients.request_json", fake_request_json)
+    import app.http as http_module
+
+    assert http_module.request_json is fake_request_json
+
+    async with lifespan(app):
+        from app.cache import init_cache
+
+        await init_cache(get_settings())
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            first = await client.get("/tmdb/movie/1")
+            assert first.status_code == 200, first.text
+            first_payload = first.json()
+            assert first_payload["provider"] == "tmdb"
+            assert first_payload["cached"] is False
+            assert "fetched_at" in first_payload
+
+            second = await client.get("/tmdb/movie/1")
+            assert second.status_code == 200
+            second_payload = second.json()
+            assert second_payload["cached"] is True
+            assert second_payload["provider"] == "tmdb"
+
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- add a FastAPI-based metadata proxy service with caching, rate limiting, and provider routers
- wire docker-compose to run the proxy and pass METADATA_BASE_URL to the API
- introduce a backend metadata client and route TMDB movie/TV plus Last.fm album lookups through the proxy
- cover proxy behaviour with health and TMDB caching tests

## Testing
- pytest services/metadata-proxy/tests