### PR TITLE
Fix metadata proxy service definition in docker compose

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -150,14 +150,6 @@ services:
       api:
         condition: service_healthy
 
-
-volumes:
-  db_data:
-  redis_data:
-  qb_config:
-  downloads:
-  music:
-
   metadata-proxy:
     build:
       context: ../services/metadata-proxy
@@ -168,3 +160,11 @@ volumes:
       interval: 30s
       timeout: 5s
       retries: 5
+
+
+volumes:
+  db_data:
+  redis_data:
+  qb_config:
+  downloads:
+  music:


### PR DESCRIPTION
## Summary
- move the metadata-proxy service back under the services block in docker-compose
- clean up the volumes section so it only defines named volumes

## Testing
- not run (docker not available in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e57419cbb08329a06506a07c20952c